### PR TITLE
add onMouseOver feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ React D3 Tree is a [React](http://facebook.github.io/react/) component that lets
 - [Node shapes](#node-shapes)
 - [Styling](#styling)
 - [External data sources](#external-data-sources)
+- [Recipes](#recipes)
 
 
 ## Demo
@@ -204,3 +205,7 @@ class MyComponent extends React.Component {
 
 For details regarding the `treeUtil` module, please check the module's [API docs](docs/util/util.md).  
 For examples of each data type that can be parsed with `treeUtil`, please check the [data source examples](docs/examples/data).
+
+
+## Recipes
+* [Auto-centering inside `treeContainer`](https://codesandbox.io/s/vvz51w5n63)

--- a/src/Node/index.js
+++ b/src/Node/index.js
@@ -20,6 +20,7 @@ export default class Node extends React.Component {
     };
 
     this.handleClick = this.handleClick.bind(this);
+    this.handleOnMouseOver = this.handleOnMouseOver.bind(this);
   }
 
   componentDidMount() {
@@ -75,6 +76,10 @@ export default class Node extends React.Component {
     this.props.onClick(this.props.nodeData.id);
   }
 
+  handleOnMouseOver() {
+    this.props.onMouseOver(this.props.nodeData.id);
+  }
+
   componentWillLeave(done) {
     const { nodeData: { parent }, orientation, transitionDuration } = this.props;
     const originX = parent ? parent.x : 0;
@@ -97,6 +102,8 @@ export default class Node extends React.Component {
         className={nodeData._children ? 'nodeBase' : 'leafNodeBase'}
         transform={this.state.transform}
         onClick={this.handleClick}
+        onMouseOver={this.handleOnMouseOver}
+        onFocus={this.handleOnMouseOver}
       >
         {/* TODO: DEPRECATE <circle /> */}
         {this.props.circleRadius ? (
@@ -142,6 +149,7 @@ Node.defaultProps = {
   textAnchor: 'start',
   attributes: undefined,
   circleRadius: undefined,
+  onMouseOver: undefined,
   styles: {
     node: {
       circle: {},
@@ -162,6 +170,7 @@ Node.propTypes = {
   orientation: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
   transitionDuration: PropTypes.number.isRequired,
   onClick: PropTypes.func.isRequired,
+  onMouseOver: PropTypes.func,
   name: PropTypes.string.isRequired,
   attributes: PropTypes.object,
   textLayout: PropTypes.object.isRequired,


### PR DESCRIPTION
I was unsure how to test this.  How are you running the environment locally?  

I copied the format of the onClick handler, let me know if I should add to the test files or ReadME, or what you need.  I didn't include in "Node  index.test.js" because its an optional prop, but I'm seeing that reduced coverall coverage.

I ran `npm run dev` and it gave me an error that onFocus must accompany onMouseOver for accessibility reasons, so I added onFocus as well.

Let me know