### PR TITLE
Added ability to render foreignObject in svg and added noTextNested param

### DIFF
--- a/src/Node/index.js
+++ b/src/Node/index.js
@@ -93,19 +93,15 @@ export default class Node extends React.Component {
     this.applyTransform(transform, transitionDuration, 0, done);
   }
 
-  renderForeignObjectData(foreignObjectData, nodeData) {
-    if (foreignObjectData.dataWrapper) {
-      if (typeof foreignObjectData.dataWrapper.content === 'function') return foreignObjectData.dataWrapper.content(nodeData)
-      return (
-        <div {...foreignObjectData.dataWrapper.params} dangerouslySetInnerHTML={foreignObjectData.dataWrapper.content} />
-      )
-    }
-    console.warn("dataWrapper for foreignObjectData should be specified")
-    return null
-  }
-
   render() {
-    const { nodeData, nodeSvgShape, textLayout, styles, foreignObjectData, noTextNested } = this.props;
+    const {
+      nodeData,
+      nodeSvgShape,
+      textLayout,
+      styles,
+      foreignObjectData,
+      noTextNested,
+    } = this.props;
     const nodeStyle = nodeData._children ? { ...styles.node } : { ...styles.leafNode };
     return (
       <g
@@ -129,41 +125,37 @@ export default class Node extends React.Component {
             ...nodeStyle.circle,
           })
         )}
-        {
-          !noTextNested &&
-            <text
-              className="nodeNameBase"
-              style={nodeStyle.name}
-              textAnchor={textLayout.textAnchor}
-              x={textLayout.x}
-              y={textLayout.y}
-              transform={textLayout.transform}
-              dy=".35em"
-            >
-              {this.props.name}
-            </text>
-        }
-        {
-          !noTextNested &&
-            <text
-              className="nodeAttributesBase"
-              y={textLayout.y + 10}
-              textAnchor={textLayout.textAnchor}
-              transform={textLayout.transform}
-              style={nodeStyle.attributes}
-            >
-            </text>
-        }
-        {
-          nodeData && nodeData.dangerouslySetInnerHTML
-            ? <foreignObject><div dangerouslySetInnerHTML={{__html: nodeData.dangerouslySetInnerHTML}} /></foreignObject>
-            : foreignObjectData && Object.keys(foreignObjectData).length &&
-            <foreignObject 
-              {...foreignObjectData.params}
-            >
-              {this.renderForeignObjectData(foreignObjectData, nodeData)}
+
+        {!noTextNested && (
+          <text
+            className="nodeNameBase"
+            style={nodeStyle.name}
+            textAnchor={textLayout.textAnchor}
+            x={textLayout.x}
+            y={textLayout.y}
+            transform={textLayout.transform}
+            dy=".35em"
+          >
+            {this.props.name}
+          </text>
+        )}
+
+        {!noTextNested && (
+          <text
+            className="nodeAttributesBase"
+            y={textLayout.y + 10}
+            textAnchor={textLayout.textAnchor}
+            transform={textLayout.transform}
+            style={nodeStyle.attributes}
+          />
+        )}
+
+        {foreignObjectData &&
+          Object.keys(foreignObjectData).length && (
+            <foreignObject {...foreignObjectData.params}>
+              {foreignObjectData.content(nodeData)}
             </foreignObject>
-        }
+          )}
       </g>
     );
   }

--- a/src/Tree/index.js
+++ b/src/Tree/index.js
@@ -292,6 +292,8 @@ export default class Tree extends React.Component {
       separation,
       circleRadius,
       styles,
+      noTextNested,
+      foreignObjectData,
     } = this.props;
 
     const subscriptions = { ...nodeSize, ...separation, depthFactor, initialDepth };
@@ -331,6 +333,8 @@ export default class Tree extends React.Component {
                 circleRadius={circleRadius}
                 subscriptions={subscriptions}
                 styles={styles.nodes}
+                foreignObjectData={foreignObjectData}
+                noTextNested={noTextNested}
               />
             ))}
           </TransitionGroup>
@@ -369,10 +373,11 @@ Tree.defaultProps = {
   },
   circleRadius: undefined, // TODO: DEPRECATE
   styles: {},
+  noTextNested: false,
+  foreignObjectData: undefined,
 };
 
 Tree.propTypes = {
-  data: PropTypes.array.isRequired,
   nodeSvgShape: PropTypes.shape({
     shape: PropTypes.string,
     shapeProps: PropTypes.object,
@@ -412,4 +417,24 @@ Tree.propTypes = {
     nodes: PropTypes.object,
     links: PropTypes.object,
   }),
+  data: PropTypes.array.isRequired,
+  foreignObjectData: PropTypes.shape({
+    style: PropTypes.object,
+    width: PropTypes.string,
+    height: PropTypes.string,
+    x: PropTypes.string,
+    y: PropTypes.string,
+    dataWrapper: PropTypes.shape({
+      params: PropTypes.shape({
+        width: PropTypes.string,
+        height: PropTypes.string,
+        style: PropTypes.object,
+      }),
+      content: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+      ]),
+    }),
+  }),
+  noTextNested: PropTypes.bool,
 };

--- a/src/Tree/index.js
+++ b/src/Tree/index.js
@@ -207,9 +207,9 @@ export default class Tree extends React.Component {
 
   /**
    * handleOnMouseOverCb - Handles the user-defined `onMouseOver` function
-   * 
-   * @param {string} nodeId 
-   * 
+   *
+   * @param {string} nodeId
+   *
    * @return {void}
    */
   handleOnMouseOverCb(nodeId) {
@@ -224,9 +224,9 @@ export default class Tree extends React.Component {
 
   /**
    * handleOnMouseOutCb - Handles the user-defined `onMouseOut` function
-   * 
-   * @param {string} nodeId 
-   * 
+   *
+   * @param {string} nodeId
+   *
    * @return {void}
    */
   handleOnMouseOutCb(nodeId) {
@@ -292,8 +292,8 @@ export default class Tree extends React.Component {
       separation,
       circleRadius,
       styles,
-      noTextNested,
       foreignObjectData,
+      noTextNested,
     } = this.props;
 
     const subscriptions = { ...nodeSize, ...separation, depthFactor, initialDepth };
@@ -373,8 +373,8 @@ Tree.defaultProps = {
   },
   circleRadius: undefined, // TODO: DEPRECATE
   styles: {},
-  noTextNested: false,
   foreignObjectData: undefined,
+  noTextNested: false,
 };
 
 Tree.propTypes = {
@@ -419,22 +419,14 @@ Tree.propTypes = {
   }),
   data: PropTypes.array.isRequired,
   foreignObjectData: PropTypes.shape({
-    style: PropTypes.object,
-    width: PropTypes.string,
-    height: PropTypes.string,
-    x: PropTypes.string,
-    y: PropTypes.string,
-    dataWrapper: PropTypes.shape({
-      params: PropTypes.shape({
-        width: PropTypes.string,
-        height: PropTypes.string,
-        style: PropTypes.object,
-      }),
-      content: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.func,
-      ]),
+    params: PropTypes.shape({
+      style: PropTypes.object,
+      width: PropTypes.string,
+      height: PropTypes.string,
+      x: PropTypes.string,
+      y: PropTypes.string,
     }),
+    content: PropTypes.func,
   }),
   noTextNested: PropTypes.bool,
 };


### PR DESCRIPTION
Added ability to render foreignObject. By adding foreignObjectData prop to tree component.
foreignObjectData: {
    params: {
        style: {}, // style object of foreignObject
        width: '', // height of foreignObject
        height: '', // height of foreignObject
        x: '', // x position of foreignObject
        y: '', // y position of foreignObject
    },
    content: '', // function that gets the data for current node and returns react component
}
noTextNested - needs to fix for older react versions, that throws errors for text tags nested in svg 

(firstly i made two ways of rendering own html in foreignObject: react way and html text, but had to remove dangerouslySetInnerHTML that was used to render html by string directly from data of the node, because get errors in Codacy/PR Quality Review)