### PR TITLE
restoring original initialDepth functionality

### DIFF
--- a/src/Tree/index.js
+++ b/src/Tree/index.js
@@ -313,12 +313,12 @@ export default class Tree extends React.Component {
       .children(d => (d._collapsed ? null : d._children));
 
     const rootNode = this.state.data[0];
-    const nodes = tree.nodes(rootNode);
-    const links = tree.links(nodes);
+    let nodes = tree.nodes(rootNode);
 
     // set `initialDepth` on first render if specified
     if (initialDepth !== undefined && this.internalState.initialRender) {
       this.setInitialTreeDepth(nodes, initialDepth);
+      nodes = tree.nodes(rootNode);
     }
 
     if (depthFactor) {
@@ -327,6 +327,7 @@ export default class Tree extends React.Component {
       });
     }
 
+    const links = tree.links(nodes);
     return { nodes, links };
   }
 


### PR DESCRIPTION
My company is currently using react-d3-tree and I ran across the recently open issue regarding the initialDepth parameter: https://github.com/bkrem/react-d3-tree/issues/99

Since I need this functionality for a feature I'm developing, I spent some time looking for a fix in our fork and thought I might as well put up a PR here. This should get initialDepth working, but I didn't want to mess around with committing the min.js unless it's necessary. Let me know what you think! 