### PR TITLE
Add data-source-id, data-target-id on Link

### DIFF
--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -110,6 +110,8 @@ export default class Link extends React.PureComponent {
         onClick={this.handleOnClick}
         onMouseOver={this.handleOnMouseOver}
         onMouseOut={this.handleOnMouseOut}
+        data-source-id={this.props.linkData.source.id}
+        data-target-id={this.props.linkData.target.id}
       />
     );
   }

--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -110,8 +110,8 @@ export default class Link extends React.PureComponent {
         onClick={this.handleOnClick}
         onMouseOver={this.handleOnMouseOver}
         onMouseOut={this.handleOnMouseOut}
-        data-source-id={this.props.linkData.source.id || this.props.linkData.source}
-        data-target-id={this.props.linkData.target.id || this.props.linkData.target}
+        data-source-id={this.props.linkData.source.id}
+        data-target-id={this.props.linkData.target.id}
       />
     );
   }

--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -110,8 +110,8 @@ export default class Link extends React.PureComponent {
         onClick={this.handleOnClick}
         onMouseOver={this.handleOnMouseOver}
         onMouseOut={this.handleOnMouseOut}
-        data-source-id={this.props.linkData.source.id}
-        data-target-id={this.props.linkData.target.id}
+        data-source-id={this.props.linkData.source.id || this.props.linkData.source}
+        data-target-id={this.props.linkData.target.id || this.props.linkData.target}
       />
     );
   }

--- a/src/Link/tests/index.test.js
+++ b/src/Link/tests/index.test.js
@@ -66,12 +66,6 @@ describe('<Link />', () => {
     delete linkData.target.id
   });
   
-  it('binds the full source & target to data-source-id/data-target-id if "id" not in source/target', () => {
-    const renderedComponent = shallow(<Link {...mockProps} />);
-    expect(renderedComponent.find('path').prop('data-source-id')).toEqual(linkData.source);
-    expect(renderedComponent.find('path').prop('data-target-id')).toEqual(linkData.target);
-  });
-  
   it('calls the appropriate path func based on `props.pathFunc`', () => {
     const diagonalComponent = shallow(<Link {...mockProps} />);
     const elbowComponent = shallow(<Link {...mockProps} pathFunc="elbow" />);

--- a/src/Link/tests/index.test.js
+++ b/src/Link/tests/index.test.js
@@ -56,6 +56,22 @@ describe('<Link />', () => {
     expect(renderedComponent.prop('style')).toEqual(fixture);
   });
 
+  it('binds IDs of source & target nodes to data-source-id/data-target-id', () => {
+    linkData.source.id = 1;
+    linkData.target.id = 2;
+    const renderedComponent = shallow(<Link {...mockProps} />);
+    expect(renderedComponent.find('path').prop('data-source-id')).toEqual(linkData.source.id);
+    expect(renderedComponent.find('path').prop('data-target-id')).toEqual(linkData.target.id);
+    delete linkData.source.id;
+    delete linkData.target.id
+  });
+  
+  it('binds the full source & target to data-source-id/data-target-id if "id" not in source/target', () => {
+    const renderedComponent = shallow(<Link {...mockProps} />);
+    expect(renderedComponent.find('path').prop('data-source-id')).toEqual(linkData.source);
+    expect(renderedComponent.find('path').prop('data-target-id')).toEqual(linkData.target);
+  });
+  
   it('calls the appropriate path func based on `props.pathFunc`', () => {
     const diagonalComponent = shallow(<Link {...mockProps} />);
     const elbowComponent = shallow(<Link {...mockProps} pathFunc="elbow" />);


### PR DESCRIPTION
It helps finding links between nodes (i.e. on node mouseOver, find the links related to this node.)

![2019_09_04__14_09_52](https://user-images.githubusercontent.com/4764837/64250326-804cdc00-cf1e-11e9-9553-b4cb49793471.png)
