### PR TITLE
Added assignable id method for nodes

### DIFF
--- a/src/Tree/index.js
+++ b/src/Tree/index.js
@@ -144,7 +144,9 @@ class Tree extends React.Component {
     // Wrap the root node into an array for recursive transformations if it wasn't in one already.
     const d = Array.isArray(data) ? data : [data];
     return d.map(node => {
-      node.id = uuid.v4();
+      // If the node has an attribute named 'id', use that reference, otherwise, generate it randomly
+      node.id = node.attributes.id ? node.attributes.id : uuid.v4();
+
       // If the node's `_collapsed` state wasn't defined by the data set -> default to `false`.
       if (node._collapsed === undefined) {
         node._collapsed = false;


### PR DESCRIPTION
The modification allows to assign an id you want to the node.id through the data object, with an "id" attribute included in the data structure from where the nodes will be generate, and if there is no value assigned, it will receive a random id. This is useful to implement search functionality to your tree if you're going to manage an id database; i.e. a user tree for a web page with assigned id to each user to search and track them in the tree. The function 'findNodesById' can be referenced and used for the search-ability.