### PR TITLE
add func for stairlike links rendering

### DIFF
--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -37,8 +37,8 @@ export default class Link extends React.PureComponent {
     const deltaY = target.y - source.y;
 
     return orientation === 'horizontal'
-      ? `M${source.x},${source.y} V${source.y + deltaY / 2} H${target.x} V${target.y}`
-      : `M${source.y},${source.x} H${source.y + deltaY / 2} V${target.x} H${target.y}`;
+      ? `M${source.y},${source.x} H${source.y + deltaY / 2} V${target.x} H${target.y}`
+      : `M${source.x},${source.y} V${source.y + deltaY / 2} H${target.x} V${target.y}`;
   }
 
   drawDiagonalPath(linkData, orientation) {

--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -32,6 +32,15 @@ export default class Link extends React.PureComponent {
     }
   }
 
+  drawStairPath(linkData, orientation) {
+    const { source, target } = linkData;
+    const deltaY = target.y - source.y;
+
+    return orientation === 'horizontal'
+      ? `M${source.x},${source.y} V${source.y + deltaY / 2} H${target.x} V${target.y}`
+      : `M${source.y},${source.x} H${source.y + deltaY / 2} V${target.x} H${target.y}`;
+  }
+
   drawDiagonalPath(linkData, orientation) {
     const diagonal = svg
       .diagonal()
@@ -82,6 +91,10 @@ export default class Link extends React.PureComponent {
       return this.drawStraightPath(linkData, orientation);
     }
 
+    if (pathFunc === 'stair') {
+      return this.drawStairPath(linkData, orientation);
+    }
+
     return this.drawDiagonalPath(linkData, orientation);
   }
 
@@ -124,7 +137,7 @@ Link.defaultProps = {
 Link.propTypes = {
   linkData: T.object.isRequired,
   orientation: T.oneOf(['horizontal', 'vertical']).isRequired,
-  pathFunc: T.oneOfType([T.oneOf(['diagonal', 'elbow', 'straight']), T.func]).isRequired,
+  pathFunc: T.oneOfType([T.oneOf(['diagonal', 'elbow', 'straight', 'stair']), T.func]).isRequired,
   transitionDuration: T.number.isRequired,
   onClick: T.func.isRequired,
   onMouseOver: T.func.isRequired,

--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -32,7 +32,7 @@ export default class Link extends React.PureComponent {
     }
   }
 
-  drawStairPath(linkData, orientation) {
+  drawStepPath(linkData, orientation) {
     const { source, target } = linkData;
     const deltaY = target.y - source.y;
 
@@ -91,8 +91,8 @@ export default class Link extends React.PureComponent {
       return this.drawStraightPath(linkData, orientation);
     }
 
-    if (pathFunc === 'stair') {
-      return this.drawStairPath(linkData, orientation);
+    if (pathFunc === 'step') {
+      return this.drawStepPath(linkData, orientation);
     }
 
     return this.drawDiagonalPath(linkData, orientation);
@@ -137,7 +137,7 @@ Link.defaultProps = {
 Link.propTypes = {
   linkData: T.object.isRequired,
   orientation: T.oneOf(['horizontal', 'vertical']).isRequired,
-  pathFunc: T.oneOfType([T.oneOf(['diagonal', 'elbow', 'straight', 'stair']), T.func]).isRequired,
+  pathFunc: T.oneOfType([T.oneOf(['diagonal', 'elbow', 'straight', 'step']), T.func]).isRequired,
   transitionDuration: T.number.isRequired,
   onClick: T.func.isRequired,
   onMouseOver: T.func.isRequired,

--- a/src/Link/tests/index.test.js
+++ b/src/Link/tests/index.test.js
@@ -119,10 +119,10 @@ describe('<Link />', () => {
     const deltaY = target.y - source.y;
 
     expect(Link.prototype.drawStairPath(linkData, 'horizontal')).toBe(
-      `M${source.x},${source.y} V${source.y + deltaY / 2} H${target.x} V${target.y}`,
+      `M${source.y},${source.x} H${source.y + deltaY / 2} V${target.x} H${target.y}`,
     );
     expect(Link.prototype.drawStairPath(linkData, 'vertical')).toBe(
-      `M${source.y},${source.x} H${source.y + deltaY / 2} V${target.x} H${target.y}`,
+      `M${source.x},${source.y} V${source.y + deltaY / 2} H${target.x} V${target.y}`,
     );
   });
 

--- a/src/Link/tests/index.test.js
+++ b/src/Link/tests/index.test.js
@@ -114,7 +114,7 @@ describe('<Link />', () => {
     );
   });
 
-  it('return an appropriate stepPath accordin to `props.orientation`', () => {
+  it('return an appropriate stepPath according to `props.orientation`', () => {
     const { source, target } = linkData;
     const deltaY = target.y - source.y;
 

--- a/src/Link/tests/index.test.js
+++ b/src/Link/tests/index.test.js
@@ -36,6 +36,7 @@ describe('<Link />', () => {
   jest.spyOn(Link.prototype, 'drawDiagonalPath');
   jest.spyOn(Link.prototype, 'drawElbowPath');
   jest.spyOn(Link.prototype, 'drawStraightPath');
+  jest.spyOn(Link.prototype, 'drawStairPath');
   jest.spyOn(Link.prototype, 'applyOpacity');
   jest.spyOn(pathFuncs, 'testPathFunc');
 
@@ -70,13 +71,15 @@ describe('<Link />', () => {
     const diagonalComponent = shallow(<Link {...mockProps} />);
     const elbowComponent = shallow(<Link {...mockProps} pathFunc="elbow" />);
     const straightComponent = shallow(<Link {...mockProps} pathFunc="straight" />);
+    const stairComponent = shallow(<Link {...mockProps} pathFunc="stair" />);
     shallow(<Link {...mockProps} pathFunc={pathFuncs.testPathFunc} />);
 
     expect(diagonalComponent.instance().drawDiagonalPath).toHaveBeenCalled();
     expect(elbowComponent.instance().drawElbowPath).toHaveBeenCalled();
     expect(straightComponent.instance().drawStraightPath).toHaveBeenCalled();
+    expect(stairComponent.instance().drawStairPath).toHaveBeenCalled();
     expect(pathFuncs.testPathFunc).toHaveBeenCalled();
-    expect(Link.prototype.drawPath).toHaveBeenCalledTimes(4);
+    expect(Link.prototype.drawPath).toHaveBeenCalledTimes(5);
   });
 
   it('returns an appropriate elbowPath according to `props.orientation`', () => {
@@ -108,6 +111,18 @@ describe('<Link />', () => {
     );
     expect(Link.prototype.drawStraightPath(linkData, 'vertical')).toBe(
       `M${linkData.source.x},${linkData.source.y}L${linkData.target.x},${linkData.target.y}`,
+    );
+  });
+
+  it('return an appropriate stairPath accordin to `props.orientation`', () => {
+    const { source, target } = linkData;
+    const deltaY = target.y - source.y;
+
+    expect(Link.prototype.drawStairPath(linkData, 'horizontal')).toBe(
+      `M${source.x},${source.y} V${source.y + deltaY / 2} H${target.x} V${target.y}`,
+    );
+    expect(Link.prototype.drawStairPath(linkData, 'vertical')).toBe(
+      `M${source.y},${source.x} H${source.y + deltaY / 2} V${target.x} H${target.y}`,
     );
   });
 

--- a/src/Link/tests/index.test.js
+++ b/src/Link/tests/index.test.js
@@ -36,7 +36,7 @@ describe('<Link />', () => {
   jest.spyOn(Link.prototype, 'drawDiagonalPath');
   jest.spyOn(Link.prototype, 'drawElbowPath');
   jest.spyOn(Link.prototype, 'drawStraightPath');
-  jest.spyOn(Link.prototype, 'drawStairPath');
+  jest.spyOn(Link.prototype, 'drawStepPath');
   jest.spyOn(Link.prototype, 'applyOpacity');
   jest.spyOn(pathFuncs, 'testPathFunc');
 
@@ -71,13 +71,13 @@ describe('<Link />', () => {
     const diagonalComponent = shallow(<Link {...mockProps} />);
     const elbowComponent = shallow(<Link {...mockProps} pathFunc="elbow" />);
     const straightComponent = shallow(<Link {...mockProps} pathFunc="straight" />);
-    const stairComponent = shallow(<Link {...mockProps} pathFunc="stair" />);
+    const stepComponent = shallow(<Link {...mockProps} pathFunc="step" />);
     shallow(<Link {...mockProps} pathFunc={pathFuncs.testPathFunc} />);
 
     expect(diagonalComponent.instance().drawDiagonalPath).toHaveBeenCalled();
     expect(elbowComponent.instance().drawElbowPath).toHaveBeenCalled();
     expect(straightComponent.instance().drawStraightPath).toHaveBeenCalled();
-    expect(stairComponent.instance().drawStairPath).toHaveBeenCalled();
+    expect(stepComponent.instance().drawStepPath).toHaveBeenCalled();
     expect(pathFuncs.testPathFunc).toHaveBeenCalled();
     expect(Link.prototype.drawPath).toHaveBeenCalledTimes(5);
   });
@@ -114,14 +114,14 @@ describe('<Link />', () => {
     );
   });
 
-  it('return an appropriate stairPath accordin to `props.orientation`', () => {
+  it('return an appropriate stepPath accordin to `props.orientation`', () => {
     const { source, target } = linkData;
     const deltaY = target.y - source.y;
 
-    expect(Link.prototype.drawStairPath(linkData, 'horizontal')).toBe(
+    expect(Link.prototype.drawStepPath(linkData, 'horizontal')).toBe(
       `M${source.y},${source.x} H${source.y + deltaY / 2} V${target.x} H${target.y}`,
     );
-    expect(Link.prototype.drawStairPath(linkData, 'vertical')).toBe(
+    expect(Link.prototype.drawStepPath(linkData, 'vertical')).toBe(
       `M${source.x},${source.y} V${source.y + deltaY / 2} H${target.x} V${target.y}`,
     );
   });


### PR DESCRIPTION
I made stair-like link paths. I think it's missing functionality because it's useful for advanced hierarchy like organizational charts.

Examples:
<img width="1345" alt="Screenshot 2019-12-04 at 18 38 16" src="https://user-images.githubusercontent.com/20739202/70156844-9c028280-16c5-11ea-89c5-03da10071122.png">


[VX-library](https://github.com/hshoff/vx) have a "step" type for links. You can configure and see it [here in action](https://vx-demo.now.sh/linkTypes)