### PR TITLE
Add handlers to custom node element

### DIFF
--- a/src/Node/index.tsx
+++ b/src/Node/index.tsx
@@ -119,22 +119,17 @@ export default class Node extends React.Component<NodeProps, NodeState> {
   // TODO: needs tests
   renderNodeElement = () => {
     const { data, hierarchyPointNode, renderCustomNodeElement } = this.props;
-    if (typeof renderCustomNodeElement === 'function') {
-      return renderCustomNodeElement({
+    const callable = renderCustomNodeElement === 'function' ? renderCustomNodeElement : DefaultNodeElement;
+    const nodeProps = {
         hierarchyPointNode: hierarchyPointNode,
         nodeDatum: data,
         toggleNode: this.handleNodeToggle,
-      });
-    }
+        onNodeClick: this.handleOnClick,
+        onNodeMouseOver: this.handleOnMouseOver,
+        onNodeMouseOut: this.handleOnMouseOut,
+    };
 
-    return DefaultNodeElement({
-      hierarchyPointNode: hierarchyPointNode,
-      nodeDatum: data,
-      toggleNode: this.handleNodeToggle,
-      onNodeClick: this.handleOnClick,
-      onNodeMouseOver: this.handleOnMouseOver,
-      onNodeMouseOut: this.handleOnMouseOut,
-    });
+    return callable(nodeProps)
   };
 
   handleNodeToggle = () => this.props.onNodeToggle(this.props.data.__rd3t.id);

--- a/src/Node/index.tsx
+++ b/src/Node/index.tsx
@@ -119,7 +119,7 @@ export default class Node extends React.Component<NodeProps, NodeState> {
   // TODO: needs tests
   renderNodeElement = () => {
     const { data, hierarchyPointNode, renderCustomNodeElement } = this.props;
-    const callable = renderCustomNodeElement === 'function' ? renderCustomNodeElement : DefaultNodeElement;
+    const renderNode = typeof renderCustomNodeElement === 'function' ? renderCustomNodeElement : DefaultNodeElement;
     const nodeProps = {
         hierarchyPointNode: hierarchyPointNode,
         nodeDatum: data,
@@ -129,7 +129,7 @@ export default class Node extends React.Component<NodeProps, NodeState> {
         onNodeMouseOut: this.handleOnMouseOut,
     };
 
-    return callable(nodeProps)
+    return renderNode(nodeProps)
   };
 
   handleNodeToggle = () => this.props.onNodeToggle(this.props.data.__rd3t.id);


### PR DESCRIPTION
renderCustomNodeElement should have access to all the relevant handlers, as far as i can tell. as such, here's my changes

For context, I'm trying to write my own node renderer and I also want to add onNodeMouseOver and Out handlers.

