### PR TITLE
Implementing center node on click functionality

### DIFF
--- a/src/Node/index.tsx
+++ b/src/Node/index.tsx
@@ -29,7 +29,7 @@ type NodeProps = {
   onNodeMouseOver: NodeEventHandler;
   onNodeMouseOut: NodeEventHandler;
   subscriptions: object;
-  centerNode: (hierarchyPointNode: HierarchyPointNode<TreeNodeDatum>) => void | undefined;
+  centerNode: (hierarchyPointNode: HierarchyPointNode<TreeNodeDatum>) => void;
 };
 
 type NodeState = {
@@ -60,7 +60,7 @@ export default class Node extends React.Component<NodeProps, NodeState> {
 
   componentDidUpdate() {
     if (this.state.wasClicked) {
-      this.props.centerNode && this.props.centerNode(this.props.hierarchyPointNode);
+      this.props.centerNode(this.props.hierarchyPointNode);
       this.setState({ wasClicked: false });
     }
     this.commitTransform();
@@ -141,12 +141,12 @@ export default class Node extends React.Component<NodeProps, NodeState> {
   };
 
   handleNodeToggle = () => {
-    this.setState({ ...this.state, wasClicked: true });
+    this.setState({ wasClicked: true });
     this.props.onNodeToggle(this.props.data.__rd3t.id);
   };
 
   handleOnClick = evt => {
-    this.setState({ ...this.state, wasClicked: true });
+    this.setState({ wasClicked: true });
     this.props.onNodeClick(this.props.hierarchyPointNode, evt);
   };
 

--- a/src/Node/index.tsx
+++ b/src/Node/index.tsx
@@ -29,11 +29,13 @@ type NodeProps = {
   onNodeMouseOver: NodeEventHandler;
   onNodeMouseOut: NodeEventHandler;
   subscriptions: object;
+  centerNode: (hierarchyPointNode: HierarchyPointNode<TreeNodeDatum>) => void | undefined;
 };
 
 type NodeState = {
   transform: string;
   initialStyle: { opacity: number };
+  wasClicked: boolean;
 };
 
 export default class Node extends React.Component<NodeProps, NodeState> {
@@ -49,6 +51,7 @@ export default class Node extends React.Component<NodeProps, NodeState> {
     initialStyle: {
       opacity: 0,
     },
+    wasClicked: false,
   };
 
   componentDidMount() {
@@ -56,6 +59,10 @@ export default class Node extends React.Component<NodeProps, NodeState> {
   }
 
   componentDidUpdate() {
+    if (this.state.wasClicked) {
+      this.props.centerNode && this.props.centerNode(this.props.hierarchyPointNode);
+      this.setState({ wasClicked: false });
+    }
     this.commitTransform();
   }
 
@@ -119,22 +126,27 @@ export default class Node extends React.Component<NodeProps, NodeState> {
   // TODO: needs tests
   renderNodeElement = () => {
     const { data, hierarchyPointNode, renderCustomNodeElement } = this.props;
-    const renderNode = typeof renderCustomNodeElement === 'function' ? renderCustomNodeElement : DefaultNodeElement;
+    const renderNode =
+      typeof renderCustomNodeElement === 'function' ? renderCustomNodeElement : DefaultNodeElement;
     const nodeProps = {
-        hierarchyPointNode: hierarchyPointNode,
-        nodeDatum: data,
-        toggleNode: this.handleNodeToggle,
-        onNodeClick: this.handleOnClick,
-        onNodeMouseOver: this.handleOnMouseOver,
-        onNodeMouseOut: this.handleOnMouseOut,
+      hierarchyPointNode: hierarchyPointNode,
+      nodeDatum: data,
+      toggleNode: this.handleNodeToggle,
+      onNodeClick: this.handleOnClick,
+      onNodeMouseOver: this.handleOnMouseOver,
+      onNodeMouseOut: this.handleOnMouseOut,
     };
 
-    return renderNode(nodeProps)
+    return renderNode(nodeProps);
   };
 
-  handleNodeToggle = () => this.props.onNodeToggle(this.props.data.__rd3t.id);
+  handleNodeToggle = () => {
+    this.setState({ ...this.state, wasClicked: true });
+    this.props.onNodeToggle(this.props.data.__rd3t.id);
+  };
 
   handleOnClick = evt => {
+    this.setState({ ...this.state, wasClicked: true });
     this.props.onNodeClick(this.props.hierarchyPointNode, evt);
   };
 

--- a/src/Tree/index.tsx
+++ b/src/Tree/index.tsx
@@ -393,19 +393,19 @@ class Tree extends React.Component<TreeProps, TreeState> {
    * @param hierarchyPointNode
    */
   centerNode = (hierarchyPointNode: HierarchyPointNode<TreeNodeDatum>) => {
-    const g = select(`.${this.gInstanceRef}`);
-    const svg = select(`.${this.svgInstanceRef}`);
-    const scale = this.state.d3.scale;
-    //if the dimensions are given
+    // if the dimensions are given
     if (this.props.dimensions) {
+      const g = select(`.${this.gInstanceRef}`);
+      const svg = select(`.${this.svgInstanceRef}`);
+      const scale = this.state.d3.scale;
+
       let x, y;
-      //if the orientation is horizontal
+      // if the orientation is horizontal, calculate the variables inverted (x->y, y->x)
       if (this.props.orientation === 'horizontal') {
-        //calculate the variables inverted (x->y, y->x)
         y = -hierarchyPointNode.x * scale + this.props.dimensions.width / 2;
         x = -hierarchyPointNode.y * scale + this.props.dimensions.height / 2;
       } else {
-        //else, calculate the variables normally (x->x, y->y)
+        // else, calculate the variables normally (x->x, y->y)
         x = -hierarchyPointNode.x * scale + this.props.dimensions.width / 2;
         y = -hierarchyPointNode.y * scale + this.props.dimensions.height / 2;
       }
@@ -413,8 +413,8 @@ class Tree extends React.Component<TreeProps, TreeState> {
       g.transition()
         .duration(800)
         .attr('transform', 'translate(' + x + ',' + y + ')scale(' + scale + ')');
-      //Sets the viewport to the new center so that it does not jump back to original
-      //coordinates when dragged/zoomed
+      // Sets the viewport to the new center so that it does not jump back to original
+      // coordinates when dragged/zoomed
       //@ts-ignore
       svg.call(d3zoom().transform, zoomIdentity.translate(x, y).scale(this.props.zoom));
     }

--- a/src/Tree/types.ts
+++ b/src/Tree/types.ts
@@ -285,4 +285,14 @@ export interface TreeProps {
    * {@link Tree.defaultProps.hasInteractiveNodes | Default value}
    */
   hasInteractiveNodes?: boolean;
+
+  /**
+   * Gives the user the ability to pass dimensions of the tree container to center a node on click
+   *
+   * If dimensions are given: node will center on click. If not, node will not center on click.
+   */
+  dimensions?: {
+    height: number;
+    width: number;
+  };
 }


### PR DESCRIPTION
I love this library and everything it does. When I needed new functionality, I thought it would be a good opportunity to hopefully become a contributor!

I implemented functionality to center a node once it is clicked.

I added a few state variables and methods to allow for this functionality to be complete. Please let me know if there is anything that should be refactored to better suit the project's flow.

I believe this functionality allows for a seamless transition in projects and would be a nice feature for many users.

***USE:***
To use the new functionality, pass a `dimensions` prop object to `Tree` that contains a width(number) and height(number) of the container of the tree.

When a node is clicked (if the default click event is not overwritten) or toggled (if the default click event is overwritten), the node will send a `hierarchyPointNode` object to the new `centerNode` function.

This function then checks if dimensions were passed, if so it takes the dimensions and sets a new x,y Point depending on the orientation of the tree. It translates the viewport and sets the global viewport as to not have the node uncenter on drag/zoom.

Please let me know if you have any questions/concerns/feedback with this merge request!