### PR TITLE
Add `centeringTransitionDuration` prop to allow user to control time of transition

### DIFF
--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -82,6 +82,7 @@ class App extends Component {
       totalNodeCount: countNodes(0, Array.isArray(orgChartJson) ? orgChartJson[0] : orgChartJson),
       orientation: 'horizontal',
       dimensions: undefined,
+      centeringTransitionDuration: 800,
       translateX: 200,
       translateY: 300,
       collapsible: true,
@@ -623,6 +624,18 @@ class App extends Component {
                   onChange={this.handleChange}
                 />
               </div>
+              <div className="prop-container">
+                <label className="prop" htmlFor="centeringTransitionDuration">
+                  Centering Transition Duration
+                </label>
+                <input
+                  className="form-control"
+                  name="centeringTransitionDuration"
+                  type="number"
+                  value={this.state.centeringTransitionDuration}
+                  onChange={this.handleChange}
+                />
+              </div>
             </div>
           </div>
 
@@ -643,6 +656,7 @@ class App extends Component {
                 branchNodeClassName="demo-node"
                 orientation={this.state.orientation}
                 dimensions={this.state.dimensions}
+                centeringTransitionDuration={this.state.centeringTransitionDuration}
                 translate={{ x: this.state.translateX, y: this.state.translateY }}
                 pathFunc={this.state.pathFunc}
                 collapsible={this.state.collapsible}

--- a/src/Tree/index.tsx
+++ b/src/Tree/index.tsx
@@ -52,6 +52,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
     enableLegacyTransitions: false,
     hasInteractiveNodes: false,
     dimensions: undefined,
+    centeringTransitionDuration: 800,
   };
 
   state: TreeState = {
@@ -391,7 +392,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
    * Link: http://bl.ocks.org/robschmuecker/7880033
    */
   centerNode = (hierarchyPointNode: HierarchyPointNode<TreeNodeDatum>) => {
-    const { dimensions, orientation, zoom } = this.props;
+    const { dimensions, orientation, zoom, centeringTransitionDuration } = this.props;
     if (dimensions) {
       const g = select(`.${this.gInstanceRef}`);
       const svg = select(`.${this.svgInstanceRef}`);
@@ -410,7 +411,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
       }
       //@ts-ignore
       g.transition()
-        .duration(800)
+        .duration(centeringTransitionDuration)
         .attr('transform', 'translate(' + x + ',' + y + ')scale(' + scale + ')');
       // Sets the viewport to the new center so that it does not jump back to original
       // coordinates when dragged/zoomed

--- a/src/Tree/types.ts
+++ b/src/Tree/types.ts
@@ -134,6 +134,13 @@ export interface TreeProps {
   };
 
   /**
+   * Sets the time (in milliseconds) for the transition to center a node once clicked.
+   *
+   * {@link Tree.defaultProps.centeringTransitionDuration | Default value}
+   */
+  centeringTransitionDuration?: number;
+
+  /**
    * The draw function (or `d`) used to render `path`/`link` elements. Accepts a predefined
    * `PathFunctionOption` or a user-defined `PathFunction`.
    *


### PR DESCRIPTION
As mentioned in the original pull request for the `centerNode` function, I added a prop to allow a user to control the duration of the transition for centering a clicked node.

The new prop, named `centeringTransitionDuration` can be added to the tree and accepts a number (in milliseconds) that will control the amount of time the transition to center a node will take.

The default value is set to 800 milliseconds.

I also added the value as a customizable `number` input to the demo, so that a user can edit it in the playground.

Let me know if there are any issues with the changes.