### PR TITLE
fix: add touchmove event

### DIFF
--- a/src/Tree/index.tsx
+++ b/src/Tree/index.tsx
@@ -165,8 +165,11 @@ class Tree extends React.Component<TreeProps, TreeState> {
           return true;
         })
         .on('zoom', (event: any) => {
-          if (!this.props.draggable && (event.sourceEvent.type === 'mousemove')) {
-            return
+          if (
+            !this.props.draggable &&
+            (event.sourceEvent.type === 'mousemove' || event.sourceEvent.type === 'touchmove')
+          ) {
+            return;
           }
 
           g.attr('transform', event.transform);


### PR DESCRIPTION
The props draggable=false desn't work on mobile because the event is not "mousemove" but "touchmove".

I encountered the bug myself and saw [this opened issue](https://github.com/bkrem/react-d3-tree/issues/444)

Not a big change, just one line, but very needed in my opinion !