### PR TITLE
fix: incorrect condition on zoom event

### DIFF
--- a/src/Tree/index.tsx
+++ b/src/Tree/index.tsx
@@ -166,8 +166,9 @@ class Tree extends React.Component<TreeProps, TreeState> {
         })
         .on('zoom', (event: any) => {
           if (
-            !this.props.draggable &&
-            (event.sourceEvent.type === 'mousemove' || event.sourceEvent.type === 'touchmove')
+            !this.props.draggable ||
+            event.sourceEvent.type === 'mousemove' || 
+            event.sourceEvent.type === 'touchmove'
           ) {
             return;
           }


### PR DESCRIPTION
If we double click and drag the canvas, there will be an event that does not meet the condition and the function does not return before the attr call, so the tree is re-positioned even if draggable is false.