### PR TITLE
Updating Typing for the new method "addChildren"

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -33,6 +33,7 @@ export type PathFunction = (link: TreeLinkDatum, orientation: Orientation) => st
 export type PathClassFunction = PathFunction;
 
 export type SyntheticEventHandler = (evt: SyntheticEvent) => void;
+export type AddChildren = (children: RawNodeDatum[]) => void;
 
 /**
  * The properties that are passed to the user-defined `renderCustomNodeElement` render function.
@@ -66,6 +67,10 @@ export interface CustomNodeElementProps {
    * The `onNodeMouseOut` handler defined for `Tree` (if any).
    */
   onNodeMouseOut: SyntheticEventHandler;
+  /**
+   * The addChildren handler defined for `Tree` (if any).
+   */
+  addChildren: AddChildren;
 }
 
 export type RenderCustomNodeElementFn = (rd3tNodeProps: CustomNodeElementProps) => JSX.Element;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -68,7 +68,7 @@ export interface CustomNodeElementProps {
    */
   onNodeMouseOut: SyntheticEventHandler;
   /**
-   * The addChildren handler defined for `Tree` (if any).
+   * The `Node` class's internal `addChildren` handler.
    */
   addChildren: AddChildren;
 }


### PR DESCRIPTION
This is an addition to this MR, https://github.com/bkrem/react-d3-tree/pull/417.

Need to update the type properties for `CustomNodeElementProps` to include `addChildren`.