### PR TITLE
Additional Methods To Node Class's Internal Handlers

### DIFF
--- a/src/Node/index.tsx
+++ b/src/Node/index.tsx
@@ -7,6 +7,8 @@ import {
   TreeNodeDatum,
   RawNodeDatum,
   RenderCustomNodeElementFn,
+  UpdateChildrenFunction,
+  UpdateNodeAttributesFunction,
 } from '../types/common.js';
 import DefaultNodeElement from './DefaultNodeElement.js';
 
@@ -176,15 +178,15 @@ export default class Node extends React.Component<NodeProps, NodeState> {
     this.props.onNodeMouseOut(this.props.hierarchyPointNode, evt);
   };
 
-  handleAddChildren = childrenData => {
+  handleAddChildren: UpdateChildrenFunction = childrenData => {
     this.props.handleAddChildrenToNode(this.props.data.__rd3t.id, childrenData);
   };
 
-  handleReplaceChildren = childrenData => {
+  handleReplaceChildren: UpdateChildrenFunction = childrenData => {
     this.props.handleAddChildrenToNode(this.props.data.__rd3t.id, childrenData, true);
   };
 
-  handleUpdateNodeAttributes = attributes => {
+  handleUpdateNodeAttributes: UpdateNodeAttributesFunction = attributes => {
     this.props.handleUpdateNodeAttributes(this.props.data.__rd3t.id, attributes);
   };
 

--- a/src/Node/index.tsx
+++ b/src/Node/index.tsx
@@ -7,7 +7,6 @@ import {
   TreeNodeDatum,
   RawNodeDatum,
   RenderCustomNodeElementFn,
-  AddChildrenFunction,
 } from '../types/common.js';
 import DefaultNodeElement from './DefaultNodeElement.js';
 
@@ -36,7 +35,9 @@ type NodeProps = {
   onNodeMouseOut: NodeEventHandler;
   subscriptions: object;
   centerNode: (hierarchyPointNode: HierarchyPointNode<TreeNodeDatum>) => void;
-  handleAddChildrenToNode: (nodeId: string, children: RawNodeDatum[]) => void;
+  handleAddChildrenToNode: (nodeId: string, children: RawNodeDatum[], replace?: boolean) => void;
+  handleRemoveNode: (nodeId: string, parentNodeId: string) => void;
+  handleUpdateNodeAttributes: (nodeId: string, attributes: Omit<RawNodeDatum, 'children'>) => void;
 };
 
 type NodeState = {
@@ -149,6 +150,9 @@ export default class Node extends React.Component<NodeProps, NodeState> {
       onNodeMouseOver: this.handleOnMouseOver,
       onNodeMouseOut: this.handleOnMouseOut,
       addChildren: this.handleAddChildren,
+      removeNode: this.handleRemoveNode,
+      replaceChildren: this.handleReplaceChildren,
+      updateNodeAttributes: this.handleUpdateNodeAttributes,
     };
 
     return renderNode(nodeProps);
@@ -172,8 +176,20 @@ export default class Node extends React.Component<NodeProps, NodeState> {
     this.props.onNodeMouseOut(this.props.hierarchyPointNode, evt);
   };
 
-  handleAddChildren: AddChildrenFunction = childrenData => {
+  handleAddChildren = childrenData => {
     this.props.handleAddChildrenToNode(this.props.data.__rd3t.id, childrenData);
+  };
+
+  handleReplaceChildren = childrenData => {
+    this.props.handleAddChildrenToNode(this.props.data.__rd3t.id, childrenData, true);
+  };
+
+  handleUpdateNodeAttributes = attributes => {
+    this.props.handleUpdateNodeAttributes(this.props.data.__rd3t.id, attributes);
+  };
+
+  handleRemoveNode = () => {
+    this.props.handleRemoveNode(this.props.data.__rd3t.id, this.props.parent.data.__rd3t.id);
   };
 
   componentWillLeave(done) {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -33,8 +33,8 @@ export type PathFunction = (link: TreeLinkDatum, orientation: Orientation) => st
 export type PathClassFunction = PathFunction;
 
 export type SyntheticEventHandler = (evt: SyntheticEvent) => void;
-export type UpdateChildren = (children: RawNodeDatum[]) => void;
-export type UpdateNodeAttributes = (attributes: Omit<RawNodeDatum, 'children'>) => void;
+export type UpdateChildrenFunction = (children: RawNodeDatum[]) => void;
+export type UpdateNodeAttributesFunction = (attributes: Omit<RawNodeDatum, 'children'>) => void;
 
 /**
  * The properties that are passed to the user-defined `renderCustomNodeElement` render function.
@@ -71,15 +71,15 @@ export interface CustomNodeElementProps {
   /**
    * The `Node` class's internal `addChildren` handler.
    */
-  addChildren: UpdateChildren;
+  addChildren: UpdateChildrenFunction;
   /**
    * The `Node` class's internal `replaceChildren` handler.
    */
-  replaceChildren: UpdateChildren;
+  replaceChildren: UpdateChildrenFunction;
   /**
    * The `Node` class's internal `updateNodeAttributes` handler.
    */
-  updateNodeAttributes: UpdateNodeAttributes;
+  updateNodeAttributes: UpdateNodeAttributesFunction;
 }
 
 export type RenderCustomNodeElementFn = (rd3tNodeProps: CustomNodeElementProps) => JSX.Element;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -33,7 +33,8 @@ export type PathFunction = (link: TreeLinkDatum, orientation: Orientation) => st
 export type PathClassFunction = PathFunction;
 
 export type SyntheticEventHandler = (evt: SyntheticEvent) => void;
-export type AddChildrenFunction = (children: RawNodeDatum[]) => void;
+export type UpdateChildren = (children: RawNodeDatum[]) => void;
+export type UpdateNodeAttributes = (attributes: Omit<RawNodeDatum, 'children'>) => void;
 
 /**
  * The properties that are passed to the user-defined `renderCustomNodeElement` render function.
@@ -70,7 +71,15 @@ export interface CustomNodeElementProps {
   /**
    * The `Node` class's internal `addChildren` handler.
    */
-  addChildren: AddChildrenFunction;
+  addChildren: UpdateChildren;
+  /**
+   * The `Node` class's internal `replaceChildren` handler.
+   */
+  replaceChildren: UpdateChildren;
+  /**
+   * The `Node` class's internal `updateNodeAttributes` handler.
+   */
+  updateNodeAttributes: UpdateNodeAttributes;
 }
 
 export type RenderCustomNodeElementFn = (rd3tNodeProps: CustomNodeElementProps) => JSX.Element;


### PR DESCRIPTION
# Enhancements
The purpose of these enhancements is to give the user the ability to make dynamic updates to the tree without completely re-rendering the whole tree.

## Use Case
Handling dynamic updates like removing a node, combining nodes, and renaming nodes.

## Node Class's Internal Handlers
`removeNode: () => void`
- Removes the node and all of its children.

`replaceChildren: (children: RawNodeDatum[]) => void`
- Replaces the node's children with the given children.

`updateNodeAttributes: (attributes: Omit<RawNodeDatum, 'children'>) => void`
- Updates the `attributes` & `name` of the given node

## Additional
Updated the `key` value for Node to be more unique ( `key={'node-' + hierarchyPointNode.data.__rd3t.id}` ). Since the tree will be dynamically updating, we want the key to be unique to it's node instead of using index to prevent buggy behavior.

