### PR TITLE
Update package.json, added missing export types for module

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.t.ts",
     }
   },
   "module": "lib/esm/index.js",


### PR DESCRIPTION
Added missing type output. Resolved vscode error for not finding type declaration for react-d3-tree package